### PR TITLE
Setup script now runs a secure server + associated client changes

### DIFF
--- a/client/squawkers.js
+++ b/client/squawkers.js
@@ -184,7 +184,7 @@ class SquawkerApp extends React.Component {
 }
 
 const params = new URLSearchParams(location.search.slice(1));
-const serverUrl = params.get("janus") || "ws://localhost:8188";
+const serverUrl = params.get("janus") || `wss://${location.hostname}:8989`;
 const roomId = params.get("room") || 0;
 const ws = new WebSocket(serverUrl, "janus-protocol");
 const session = new Minijanus.JanusSession(ws.send.bind(ws));

--- a/client/tiny.js
+++ b/client/tiny.js
@@ -18,7 +18,7 @@ var c = {
 };
 
 function init() {
-  var ws = new WebSocket("ws://localhost:8188", "janus-protocol");
+  var ws = new WebSocket(`wss://${location.hostname}:8989`, "janus-protocol");
   ws.addEventListener("open", () => {
     var session = c.session = new Minijanus.JanusSession(ws.send.bind(ws));
     ws.addEventListener("message", ev => handleMessage(session, ev));


### PR DESCRIPTION
Makes it easier to setup a local janus server that mr-social-client can use without insecure connection errors.
Also important for Google Chrome support since Chrome doesn't allow getUserMedia from non-secure pages.