### PR TITLE
reformat files with cargo fmt

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,25 +1,28 @@
+use crate::messages::RoomId;
 use jsonwebtoken::{decode, Algorithm, DecodingKey, Validation};
 use serde::{Deserialize, Serialize};
 use std::error::Error;
-use crate::messages::RoomId;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ValidatedToken {
     pub join_hub: bool,
     pub kick_users: bool,
-    pub room_ids: Option<Vec<RoomId>>
+    pub room_ids: Option<Vec<RoomId>>,
 }
 
 impl ValidatedToken {
     pub fn may_join(&self, room_id: &RoomId) -> bool {
         if self.join_hub {
             if let Some(allowed_rooms) = &self.room_ids {
-                if allowed_rooms.contains(room_id) { // this token explicitly lets you in this room
+                if allowed_rooms.contains(room_id) {
+                    // this token explicitly lets you in this room
                     true
-                } else { // this token lets you in some rooms, but not this one
+                } else {
+                    // this token lets you in some rooms, but not this one
                     false
                 }
-            } else { // this token lets you in any room
+            } else {
+                // this token lets you in any room
                 true
             }
         } else {
@@ -35,7 +38,7 @@ struct UserClaims {
     #[serde(default)]
     kick_users: bool,
     #[serde(default)]
-    room_ids: Option<Vec<RoomId>>
+    room_ids: Option<Vec<RoomId>>,
 }
 
 impl ValidatedToken {

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -32,7 +32,6 @@ impl JoinState {
     }
 }
 
-
 /// The state associated with a single session.
 #[derive(Debug)]
 pub struct SessionState {
@@ -48,7 +47,6 @@ pub struct SessionState {
     // todo: these following fields should be unified with the JoinState, but it's
     // annoying in practice because they are established during JSEP negotiation
     // rather than during the join flow
-
     /// If this is a subscriber, the subscription this user has established, if any.
     pub subscription: OnceCell<Subscription>,
 

--- a/src/switchboard.rs
+++ b/src/switchboard.rs
@@ -2,9 +2,9 @@ use crate::messages::{RoomId, UserId};
 use crate::sessions::Session;
 use janus_plugin::janus_err;
 use std::borrow::Borrow;
+use std::collections::hash_map::Entry;
 /// Tools for managing the set of subscriptions between connections.
 use std::collections::HashMap;
-use std::collections::hash_map::Entry;
 use std::fmt::Debug;
 use std::hash::Hash;
 use std::sync::Arc;
@@ -260,9 +260,7 @@ impl Switchboard {
     }
 
     pub fn get_room_users(&self, room: &RoomId) -> impl Iterator<Item = &UserId> {
-        self.publishers_occupying(room).iter().filter_map(|s| {
-            s.join_state.get().map(|j| &j.user_id)
-        })
+        self.publishers_occupying(room).iter().filter_map(|s| s.join_state.get().map(|j| &j.user_id))
     }
 
     pub fn get_all_users(&self) -> impl Iterator<Item = &UserId> {


### PR DESCRIPTION
@mqp I started reading the Rust book to learn the language properly. I installed the Rust addon in VS Code that format the code with rustfmt / cargo fmt on save. It seems that recent changes to the code weren't formatted with rustfmt or maybe recent rustfmt versions changed default formatting? You tell me.
If you want you can merge this PR to fix that. Or just do your own commit to reformat at least `src/lib.rs` that's the file I will mainly modify.
I thought that reformatting the files before doing any new PR with code changes would facilitate the review on future PRs. If you don't merge it, I'll try to not include the formatting changes in future PRs.

I see it adds trailing comma. rustfmt doesn't seem to have a stable option to not add them.
I used rustup for my rust installation
```
rustc --version
rustc 1.53.0 (53cb7b09b 2021-06-17)
rustfmt --version
rustfmt 1.4.37-stable (2a3635d 2021-05-04)
```