### PR TITLE
Add GitHub actions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,6 +16,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Install libjansson-dev
+      run: sudo apt-get install libjansson-dev
     - name: Build
       run: cargo build --verbose
     - name: Run tests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,22 @@
+name: Rust
+
+on:
+  push:
+    branches: [ github-actions ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,7 +2,7 @@ name: Rust
 
 on:
   push:
-    branches: [ github-actions ]
+    branches: [ master ]
   pull_request:
     branches: [ master ]
 


### PR DESCRIPTION
Add GitHub actions to run `cargo build` and `cargo test` like we did before with travis.
It works great:
![Capture d’écran de 2021-07-10 10-14-42](https://user-images.githubusercontent.com/112249/125156831-d2d53000-e167-11eb-830a-a81f349f43a4.png)
