### PR TITLE
Optimize block/unblock

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -541,8 +541,10 @@ fn process_block(from: &Arc<Session>, whom: UserId) -> MessageResult {
     janus_info!("Processing block from {:p} to {}", from.handle, whom);
     if let Some(joined) = from.join_state.get() {
         let mut switchboard = SWITCHBOARD.write()?;
-        let event = json!({ "event": "blocked", "by": &joined.user_id });
-        notify_user(&event, &whom, switchboard.publishers_occupying(&joined.room_id));
+        if let Some(publisher) = switchboard.get_publisher(&whom) {
+            let event = json!({ "event": "blocked", "by": &joined.user_id });
+            notify_user(&event, &whom, &[publisher]);
+        }
         switchboard.establish_block(joined.user_id.clone(), whom);
         Ok(MessageResponse::msg(json!({})))
     } else {
@@ -557,9 +559,9 @@ fn process_unblock(from: &Arc<Session>, whom: UserId) -> MessageResult {
         switchboard.lift_block(&joined.user_id, &whom);
         if let Some(publisher) = switchboard.get_publisher(&whom) {
             send_fir(&[publisher]);
+            let event = json!({ "event": "unblocked", "by": &joined.user_id });
+            notify_user(&event, &whom, &[publisher]);
         }
-        let event = json!({ "event": "unblocked", "by": &joined.user_id });
-        notify_user(&event, &whom, switchboard.publishers_occupying(&joined.room_id));
         Ok(MessageResponse::msg(json!({})))
     } else {
         Err(From::from("Cannot unblock when not in a room."))


### PR DESCRIPTION
See #80 
Now that get_publisher is optimized and cost is O(1) , prefer using it instead of iterating over publishers in the room to send the blocked/unblocked event to the blocked user.
Well this may not be a big optimization, this is more for code readability and also to avoid having something like
```
        for room in &joined.room_ids {
            notify_user(&event, &whom, switchboard.publishers_occupying(&room));
        }
```
if a publisher is in several rooms, see https://github.com/mozilla/janus-plugin-sfu/issues/55#issuecomment-778065876 for context.

I tested it with the naf-adapter-janus example, the messages are still sent:
![Capture d’écran de 2021-07-10 11-37-52](https://user-images.githubusercontent.com/112249/125159137-d66fb380-e175-11eb-9906-d2e57560896d.png)
